### PR TITLE
Remove paths-ignore for develop PRs

### DIFF
--- a/.github/workflows/develop_CI.yml
+++ b/.github/workflows/develop_CI.yml
@@ -2,11 +2,6 @@ name: Build_CI_Vue_Dev
 
 on:
   pull_request:
-    paths-ignore: # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      - "**/README.md"
-      - "**/dependabot.yml"
-      - ".github/workflows/develop_CD.yml"
-      - ".github/workflows/main_CD.yml"
     branches:
       - develop
 


### PR DESCRIPTION
Since the CI build is a required check this is blocking certain dependabot PRs e.g. https://github.com/IATI/validator-web/pull/452, and it seems safe to remove them, given that nothing auto-merges to `main` or gets released without a human.