### PR TITLE
Split footer section into columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,10 @@
 
       <!-- IATI Design System -->
       <link
-        href="https://cdn.jsdelivr.net/npm/iati-design-system@3.4.0/dist/css/iati.min.css"
+        href="https://cdn.jsdelivr.net/npm/iati-design-system@3.5.0/dist/css/iati.min.css"
         rel="stylesheet"
       />
-      <script src="https://cdn.jsdelivr.net/npm/iati-design-system@3.4.0/dist/js/iati.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/iati-design-system@3.5.0/dist/js/iati.js"></script>
       <!-- End IATI Design System -->
   </head>
   <body>

--- a/src/components/layout/LayoutFooter.vue
+++ b/src/components/layout/LayoutFooter.vue
@@ -40,29 +40,33 @@
 <template>
   <footer class="iati-footer iati-brand-background">
     <div class="iati-brand-background__content">
-      <div class="iati-footer__section iati-footer__section--first">
+      <div class="iati-footer__section">
         <div class="iati-footer__container">
           <div class="iati-footer-block">
             <h2 class="iati-footer-block__title">Additional Information</h2>
-            <div class="iati-footer-block__content">
-              <p>Part of the IATI Unified Platform.</p>
-              <p>
-                Code licensed under
-                <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU AGPL</a>.
-              </p>
-              <p>
-                Documentation licensed under
-                <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
-              </p>
-              <p v-if="showVersions">
-                <a :href="releases.web.url">Web v{{ releases.web.version }}</a>
-              </p>
-              <p v-if="showVersions">
-                <a :href="releases.services.url">Services v{{ releases.services.version }}</a>
-              </p>
-              <p v-if="showVersions">
-                <a :href="releases.api.url">API v{{ releases.api.version }}</a>
-              </p>
+            <div class="iati-footer-block__content iati-footer-block__content--columns">
+              <div>
+                <p>Part of the IATI Unified Platform.</p>
+                <p>
+                  Code licensed under
+                  <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU AGPL</a>.
+                </p>
+                <p>
+                  Documentation licensed under
+                  <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
+                </p>
+              </div>
+              <div v-if="showVersions">
+                <p>
+                  <a :href="releases.web.url">Web v{{ releases.web.version }}</a>
+                </p>
+                <p>
+                  <a :href="releases.services.url">Services v{{ releases.services.version }}</a>
+                </p>
+                <p>
+                  <a :href="releases.api.url">API v{{ releases.api.version }}</a>
+                </p>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Split the "Additional Information" footer section into two columns.

Before:

![Screenshot 2025-01-08 at 10 59 36](https://github.com/user-attachments/assets/81b9cfd4-538d-4966-9f39-081e44821c9e)

After:

![Screenshot 2025-01-08 at 10 59 49](https://github.com/user-attachments/assets/a424b3a2-3a63-4cce-8b9f-22599a221155)
