### PR TITLE
Fix error where report page XML links are malformed

### DIFF
--- a/src/pages/ReportPage.vue
+++ b/src/pages/ReportPage.vue
@@ -135,7 +135,7 @@
         <RouterLink :to="`/organisation/${organisation.name}`">{{ organisation.title }}</RouterLink>
         -
       </template>
-      <RouterLink v-if="document" :to="document.url" :external="true">
+      <RouterLink v-if="document" :href="document.url" :external="true">
         {{ getDocumentFileName(document) }}
       </RouterLink>
       <div v-if="dataset && isTestFile">{{ dataset.filename }}</div>


### PR DESCRIPTION
This PR provides a hot fix for issue https://github.com/IATI/validator-web/issues/862 where links to XML files on the report page were built as an internal link on the validator site.  Think this change in behaviour is due to the removal of `<StyledLink>` which checked for external URLs first and used `:href` instead of `:to` in those cases.  Changed this `<RouterLink>` to set the link using `:href` as we know links to XML files will be external to the validator.  This PR does not check the rest of the application for similar instances.