### PR TITLE
Improved fix for XML URL links on report page

### DIFF
--- a/cypress/integration/validationReport.spec.js
+++ b/cypress/integration/validationReport.spec.js
@@ -139,4 +139,14 @@ describe("The Validation Report page", () => {
       expect(loc.search).to.eq("?id=XM-TEST-VALIDATION-01-B");
     });
   });
+
+  it("opens the validation report page and presents the correct XML URLs in the document link", () => {
+    cy.fixture("validationReport01ares");
+    cy.intercept("**/existing?name=ares-activities", {
+      fixture: "validationReport01ares.json",
+    }).as("validation");
+    cy.visit("/report/ares-activities?id=BE-BCE_KBO-0546740696-PG2017-2021_CD");
+    cy.get("[data-cy='document-url-anchor']").should("have.attr", "href", "https://aidstream.s3.us-west-2.amazonaws.com/xml/ares-activities.xml");
+    cy.get("[data-cy='document-url-anchor']").should("have.text", "ares-activities.xml");
+  });
 });

--- a/src/pages/ReportPage.vue
+++ b/src/pages/ReportPage.vue
@@ -135,9 +135,7 @@
         <RouterLink :to="`/organisation/${organisation.name}`">{{ organisation.title }}</RouterLink>
         -
       </template>
-      <RouterLink v-if="document" :href="document.url" :external="true">
-        {{ getDocumentFileName(document) }}
-      </RouterLink>
+      <a v-if="document" :href="document.url">{{ getDocumentFileName(document) }}</a>
       <div v-if="dataset && isTestFile">{{ dataset.filename }}</div>
     </h2>
     <DocumentInfo v-if="dataset && dataset.report" :document="document" :report="dataset.report" />

--- a/src/pages/ReportPage.vue
+++ b/src/pages/ReportPage.vue
@@ -135,7 +135,7 @@
         <RouterLink :to="`/organisation/${organisation.name}`">{{ organisation.title }}</RouterLink>
         -
       </template>
-      <a v-if="document" :href="document.url">{{ getDocumentFileName(document) }}</a>
+      <a data-cy="document-url-anchor" v-if="document" :href="document.url">{{ getDocumentFileName(document) }}</a>
       <div v-if="dataset && isTestFile">{{ dataset.filename }}</div>
     </h2>
     <DocumentInfo v-if="dataset && dataset.report" :document="document" :report="dataset.report" />


### PR DESCRIPTION
Changes XML URL link on report page from <RouterLink> to a standard HTML anchor.