### PR TITLE
Upgrade Node, dependencies, add workflow_dispatch

### DIFF
--- a/.github/workflows/develop_CD.yml
+++ b/.github/workflows/develop_CD.yml
@@ -1,6 +1,7 @@
 name: Deploy_To_Azure_Blobs_Dev
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore: # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       - "**/README.md" # don't run on README.md file updates anywhere in repo

--- a/.github/workflows/develop_CI.yml
+++ b/.github/workflows/develop_CI.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
       - name: Cypress CI Run
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/main_CI.yml
+++ b/.github/workflows/main_CI.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
       - name: Cypress CI Run
         uses: cypress-io/github-action@v6
         with:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/krypton

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,9 @@
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.33.1",
         "vite": "^3.2.5"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2107,9 +2110,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {
@@ -4653,9 +4656,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6548,9 +6552,9 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -8231,9 +8235,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true
     },
     "caseless": {
@@ -9932,9 +9936,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -11191,9 +11195,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "private": true,
   "version": "2.9.2",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "start": "npm run dev",
     "dev": "vite --mode development",

--- a/src/components/layout/LayoutFooter.vue
+++ b/src/components/layout/LayoutFooter.vue
@@ -68,6 +68,12 @@
                 </p>
               </div>
             </div>
+            <div class="iati-footer-block__content">
+              <div>
+                <p>Please report bugs and request features using <a href="https://github.com/IATI/validator-web/issues">GitHub issues</a> or via <a href="https://iatistandard.org/en/guidance/get-support/">IATI Support</a>.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR:

* Updates the Vite build system (and CI/CD runners) to use Node 24
* Updates the non-dev dependencies that npm flagged as having security issues.
* Adds a line of text to the footer containing two links for reporting issues, which resolves https://github.com/IATI/validator-web/issues/988
* Adds a `workflow_dispatch` trigger to dev deploy